### PR TITLE
Label duplicates in `install.selectorLabels`

### DIFF
--- a/helm/install/templates/_helpers.tpl
+++ b/helm/install/templates/_helpers.tpl
@@ -22,7 +22,6 @@ helm.sh/chart: {{ include "install.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ include "install.crunchyLabels" .}}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
It seems there is a duplicate label.
I accidentally noticed this when I've updated HelmController in FluxCI to the latest version.
The old version did not pay attention to duplicate keys in the Kubernetes manifests. Now this has been fixed (https://github.com/fluxcd/flux2/issues/1522), and the error immediately appeared when trying to install Helm Chart