### PR TITLE
Allow v4.x & v5.x Operator to Run in a Single Namespace

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v3
-name: postgres-operator
+name: pgo
 description: A Helm chart for Kubernetes
 type: application
 version: 0.1.0

--- a/kustomize/install/bases/manager/manager.yaml
+++ b/kustomize/install/bases/manager/manager.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: postgres-operator
+  name: pgo
 spec:
   replicas: 1
   template:
@@ -17,4 +17,4 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-      serviceAccountName: postgres-operator
+      serviceAccountName: pgo

--- a/kustomize/install/bases/rbac/cluster/role_binding.yaml
+++ b/kustomize/install/bases/rbac/cluster/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
   name: postgres-operator
 subjects:
 - kind: ServiceAccount
-  name: postgres-operator
+  name: pgo

--- a/kustomize/install/bases/rbac/cluster/service_account.yaml
+++ b/kustomize/install/bases/rbac/cluster/service_account.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: postgres-operator
+  name: pgo

--- a/kustomize/install/bases/rbac/namespace/role_binding.yaml
+++ b/kustomize/install/bases/rbac/namespace/role_binding.yaml
@@ -9,4 +9,4 @@ roleRef:
   name: postgres-operator
 subjects:
 - kind: ServiceAccount
-  name: postgres-operator
+  name: pgo

--- a/kustomize/install/bases/rbac/namespace/service_account.yaml
+++ b/kustomize/install/bases/rbac/namespace/service_account.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: postgres-operator
+  name: pgo


### PR DESCRIPTION
It is not currently possible to run both the v4.x and v5.x PostgreSQL
Operator in a single namespace due to a naming conflict with the
operators' respectively deployments.

This commit updates the PostgreSQL Operator v5.x installers to name
the v5.x Operator deployment 'pgo' instead of 'postgres-operator' to
allow both versions to run in the same namespace.

Also, to facilitate independent installation and removal of the 4.x
and 5.x Operators, the default service account name has been updated
in 5.x to 'pgo' in place of the current 'postgres-cluster'.

Corresponding PR [2565](https://github.com/CrunchyData/postgres-operator/pull/2565)

[ch11969]