### PR TITLE
Update secret references for managed users

### DIFF
--- a/kustomize/keycloak/keycloak.yaml
+++ b/kustomize/keycloak/keycloak.yaml
@@ -21,15 +21,15 @@ spec:
         - name: DB_VENDOR
           value: "postgres"
         - name: DB_ADDR
-          valueFrom: { secretKeyRef: { name: keycloakdb-pguser, key: host } }
+          valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: host } }
         - name: DB_PORT
-          valueFrom: { secretKeyRef: { name: keycloakdb-pguser, key: port } }
+          valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: port } }
         - name: DB_DATABASE
-          valueFrom: { secretKeyRef: { name: keycloakdb-pguser, key: dbname } }
+          valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: dbname } }
         - name: DB_USER
-          valueFrom: { secretKeyRef: { name: keycloakdb-pguser, key: user } }
+          valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: user } }
         - name: DB_PASSWORD
-          valueFrom: { secretKeyRef: { name: keycloakdb-pguser, key: password } }
+          valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: password } }
         - name: KEYCLOAK_USER
           value: "admin"
         - name: KEYCLOAK_PASSWORD


### PR DESCRIPTION
The names of PostgreSQL user secrets changed in https://github.com/CrunchyData/postgres-operator/commit/29353c2685f380b1b7874c2573ee369fc2b63f9a.