### PR TITLE
Allow to configure related images in Helm chart

### DIFF
--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -20,16 +20,10 @@ spec:
         env:
         - name: CRUNCHY_DEBUG
           value: "true"
-        - name: RELATED_IMAGE_POSTGRES_13
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha:centos8-13.4-0"
-        - name: RELATED_IMAGE_POSTGRES_13_GIS_3.1
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis-ha:centos8-13.4-3.1-0"
-        - name: RELATED_IMAGE_PGBACKREST
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.33-2"
-        - name: RELATED_IMAGE_PGBOUNCER
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-2"
-        - name: RELATED_IMAGE_PGEXPORTER
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.2-0"
+        {{- range  $image_name, $image_val := .Values.relatedImages }}
+        - name: RELATED_IMAGE_{{ $image_name | upper }}
+          value: "{{ $image_val.repository }}:{{ $image_val.tag }}"
+        {{- end }}
         {{- if .Values.singleNamespace }}
         - name: PGO_TARGET_NAMESPACE
           valueFrom: { fieldRef: { apiVersion: v1, fieldPath: metadata.namespace } }

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -4,5 +4,22 @@ image:
   repository: registry.developers.crunchydata.com/crunchydata
   tag: ubi8-5.0.2-0
 
+relatedImages:
+  postgres_13:
+    repository: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha
+    tag: centos8-13.4-0
+  postgres_13_gis_3.1:
+    repository: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis-ha
+    tag: centos8-13.4-3.1-0
+  pgbackrest:
+    repository: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest
+    tag: centos8-2.33-2
+  pgbouncer:
+    repository: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer
+    tag: centos8-1.15-2
+  pgexporter:
+    repository: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter
+    tag: ubi8-5.0.2-0
+
 ## Install in default or single namespace mode
 singleNamespace: false


### PR DESCRIPTION
The resulting resources is identical (except different ordering):

```diff
$ diff -u before after
--- before      2021-09-22 14:41:22.741520300 +0200
+++ after       2021-09-22 14:41:00.014700100 +0200
@@ -191,14 +191,14 @@
         env:
         - name: CRUNCHY_DEBUG
           value: "true"
-        - name: RELATED_IMAGE_POSTGRES_13
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha:centos8-13.4-0"
-        - name: RELATED_IMAGE_POSTGRES_13_GIS_3.1
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis-ha:centos8-13.4-3.1-0"
         - name: RELATED_IMAGE_PGBACKREST
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.33-2"
         - name: RELATED_IMAGE_PGBOUNCER
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-2"
         - name: RELATED_IMAGE_PGEXPORTER
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.1-0"
+        - name: RELATED_IMAGE_POSTGRES_13
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha:centos8-13.4-0"
+        - name: RELATED_IMAGE_POSTGRES_13_GIS_3.1
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis-ha:centos8-13.4-3.1-0"
       serviceAccount: pgo
```