### PR TITLE
Release helm charts with chart-releaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,32 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.0
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.1
+        with:
+          charts_dir: helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Fixes #23.

Prerequisites:
- Create a `gh-pages` branch (see [here](https://gist.github.com/ramnathv/2227408))

Result: I've done this in my fork, see:
- the log: https://github.com/sathieu/postgres-operator-examples/runs/3697999445
- the resulting *release*: https://github.com/sathieu/postgres-operator-examples/releases/tag/pgo-0.2.0
- the resulting chart repo: https://github.com/sathieu/postgres-operator-examples/blob/gh-pages/index.yaml