### PR TITLE
Update postgres.yaml: update backups pg_backrest docker image URI

### DIFF
--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -15,7 +15,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.33-2
+      image: crunchydata/crunchy-pgbackrest:centos8-13.4-4.7.2
       repoHost:
         dedicated: {}
       repos:


### PR DESCRIPTION
In kustomise/postgres/postgres.yaml
backup -> pgbackrest -> image points to a docker image URI which is removed recently, thus giving 404.

It was pointing to registry.developers.crunchydata.com before.
now I have updated it to point to default dockerhub.io registry.

Before: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.33-2
After: crunchydata/crunchy-pgbackrest:centos8-13.4-4.7.2