### PR TITLE
Use the Recreate strategy to update operator pods

### DIFF
--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -6,6 +6,7 @@ metadata:
     {{- include "install.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy: { type: Recreate }
   selector:
     matchLabels:
       {{- include "install.crunchyLabels" . | nindent 6 }}

--- a/kustomize/install/bases/manager/manager.yaml
+++ b/kustomize/install/bases/manager/manager.yaml
@@ -5,6 +5,7 @@ metadata:
   name: pgo
 spec:
   replicas: 1
+  strategy: { type: Recreate }
   template:
     spec:
       containers:


### PR DESCRIPTION
This reduces the chance of multiple controllers of different versions making changes concurrently.