### PR TITLE
Changed apiVersion to "v2" for Helm 3.

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v3
+apiVersion: v2
 name: pgo
 description: A Helm chart for Kubernetes
 type: application

--- a/helm/postgres/Chart.yaml
+++ b/helm/postgres/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v3
+apiVersion: v2
 name: postgrescluster
 description: A Helm chart for Kubernetes
 type: application


### PR DESCRIPTION
For both the "install" and "postgres" charts, `helm lint <chartPath>` fails with the error message:

> [ERROR] Chart.yaml: apiVersion 'v3' is not valid. The value must be either "v1" or "v2"

The [Helm documentation](https://helm.sh/docs/topics/charts/#the-apiversion-field) states that `apiVersion: v2` should be used for Helm 3 charts. This PR fixes both occurrences and causes the lints to succeed.