### PR TITLE
Change Helm related images format

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pgo
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: 5.0.3

--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -23,7 +23,7 @@ spec:
           value: "true"
         {{- range  $image_name, $image_val := .Values.relatedImages }}
         - name: RELATED_IMAGE_{{ $image_name | upper }}
-          value: "{{ $image_val.repository }}:{{ $image_val.tag }}"
+          value: "{{ $image_val.image }}"
         {{- end }}
         {{- if .Values.singleNamespace }}
         - name: PGO_TARGET_NAMESPACE

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -5,21 +5,20 @@ image:
   tag: ubi8-5.0.3-0
 
 relatedImages:
+  postgres_14:
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.0-0
+  postgres_14_gis_3.1:
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-14.0-3.1-0
   postgres_13:
-    repository: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-ha
-    tag: centos8-13.4-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
   postgres_13_gis_3.1:
-    repository: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis-ha
-    tag: centos8-13.4-3.1-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-13.4-3.1-1
   pgbackrest:
-    repository: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest
-    tag: centos8-2.33-2
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
   pgbouncer:
-    repository: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer
-    tag: centos8-1.15-2
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
   pgexporter:
-    repository: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter
-    tag: ubi8-5.0.2-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.3-0
 
 ## Install in default or single namespace mode
 singleNamespace: false


### PR DESCRIPTION
Provide ultimate flexibility by allowing user to just specify
the image itself. This avoids messy image repo / name / tag
stuff, and aligns more with convention.

closes #36