### PR TITLE
Major Helm Chart Rewrites

### DIFF
--- a/helm/postgres/Chart.yaml
+++ b/helm/postgres/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgrescluster
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: 5.0.3

--- a/helm/postgres/Chart.yaml
+++ b/helm/postgres/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgrescluster
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 5.0.3

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -1,10 +1,10 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  name: {{ .Values.name }}
+  name: {{ required "You must give your Postgres cluster a name" .Values.name }}
 spec:
-  image: {{ .Values.postgres }}
-  postgresVersion: {{ .Values.postgresVersion }}
+  image: {{ default "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1" .Values.postgres | quote }}
+  postgresVersion: {{ default 13 .Values.postgresVersion }}
   instances:
     - name: instance1
       dataVolumeClaimSpec:
@@ -15,7 +15,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: {{ .Values.pgBackRest}}
+      image: {{ default "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0" .Values.pgBackRest | quote }}
       repos:
       - name: repo1
         volume:
@@ -25,14 +25,6 @@ spec:
             resources:
               requests:
                 storage: 1Gi
-      - name: repo2
-        volume:
-          volumeClaimSpec:
-            accessModes:
-            - "ReadWriteOnce"
-            resources:
-              requests:
-                storage: 1Gi
   proxy:
     pgBouncer:
-      image: {{ .Values.pgBouncer}}
+      image: {{ default "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3" .Values.pgBouncer | quote}}

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -1,21 +1,46 @@
 apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
-  name: {{ required "You must give your Postgres cluster a name" .Values.name }}
+  name: {{ default .Release.Name .Values.name }}
 spec:
-  image: {{ default "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1" .Values.postgres | quote }}
   postgresVersion: {{ default 13 .Values.postgresVersion }}
+{{- if .Values.postGISVersion }}
+  postGISVersion: {{ quote .Values.postGISVersion }}
+{{- end }}
+{{- if .Values.imagePostgres }}
+  image: {{ .Values.imagePostgres | quote }}
+{{- end }}
+{{- if .Values.port }}
+  port: {{ .Values.port }}
+{{- end }}
+{{- if .Values.instances }}
   instances:
-    - name: instance1
+{{ toYaml .Values.instances | indent 4 }}
+{{- else }}
+  instances:
+    - name: {{ default "instance1" .Values.instanceName | quote }}
+      replicas: {{ default 1 .Values.instanceReplicas }}
       dataVolumeClaimSpec:
         accessModes:
         - "ReadWriteOnce"
         resources:
           requests:
-            storage: 1Gi
+            storage: {{ default "1Gi" .Values.instanceSize | quote }}
+{{- if or .Values.instanceMemory .Values.instanceCPU }}
+      resources:
+        limits:
+          cpu: {{ default "" .Values.instanceCPU | quote }}
+          memory: {{ default "" .Values.instanceMemory | quote }}
+{{- end }}
+{{- end }}
   backups:
     pgbackrest:
-      image: {{ default "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0" .Values.pgBackRest | quote }}
+{{- if .Values.imagePgBackRest }}
+      image: {{ .Values.imagePgBackRest | quote }}
+{{- end }}
+{{- if .Values.pgBackRestConfig }}
+{{ toYaml .Values.pgBackRestConfig | indent 6 }}
+{{- else }}
       repos:
       - name: repo1
         volume:
@@ -24,7 +49,86 @@ spec:
             - "ReadWriteOnce"
             resources:
               requests:
-                storage: 1Gi
+                storage: {{ default "1Gi" .Values.backupsSize | quote }}
+{{- end }}
+{{- if or .Values.pgBouncerReplicas .Values.pgBouncerConfig }}
   proxy:
     pgBouncer:
-      image: {{ default "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3" .Values.pgBouncer | quote}}
+{{- if .Values.imagePgBouncer }}
+      image: {{ .Values.imagePgBouncer | quote }}
+{{- end }}
+{{- if .Values.pgBouncerConfig }}
+{{ toYaml .Values.pgBouncerConfig | indent 6 }}
+{{- else }}
+      replicas: {{ .Values.pgBouncerReplicas }}
+{{- end }}
+{{- end }}
+{{- if .Values.patroni }}
+  patroni:
+{{ toYaml .Values.patroni | indent 4 }}
+{{- end }}
+{{- if .Values.users }}
+  users:
+{{ toYaml .Values.users | indent 4 }}
+{{- end }}
+{{- if .Values.service }}
+  service:
+{{ toYaml .Values.service | indent 4 }}
+{{- end }}
+{{- if .Values.dataSource }}
+  service:
+{{ toYaml .Values.dataSource | indent 4 }}
+{{- end }}
+{{- if .Values.databaseInitSQL }}
+  databaseInitSQL:
+    name: {{ required "A ConfigMap name is required for running bootstrap SQL." .Values.databaseInitSQL.name | quote }}
+    key: {{ required "A key in a ConfigMap containing any bootstrap SQL is required." .Values.databaseInitSQL.key | quote }}
+{{- end }}
+{{- if .Values.imagePullPolicy }}
+  imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+{{- end }}
+{{- if .Values.imagePullSecrets }}
+  imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 4 }}
+{{- end }}
+{{- if .Values.disableDefaultPodScheduling }}
+  disableDefaultPodScheduling: true
+{{- end }}
+{{- if .Values.metadata }}
+  metadata:
+{{ toYaml .Values.metadata | indent 4 }}
+{{- end }}
+{{- if .Values.monitoring }}
+  monitoring:
+    pgmonitor:
+      exporter:
+        image: {{ default "" .Values.imageExporter | quote }}
+{{- if .Values.monitoringConfig }}
+{{ toYaml .Values.monitoringConfig | indent 8 }}
+{{- end }}
+{{- end }}
+{{- if .Values.shutdown }}
+  shutdown: true
+{{- end }}
+{{- if .Values.standby }}
+  standby:
+    enabled: {{ .Values.standby.enabled }}
+    repoName: {{ required "repoName must be set when enabling standby mode." .Values.standby.repoName }}
+{{- end }}
+{{- if .Values.supplementalGroups }}
+  supplementalGroups:
+{{ toYaml .Values.supplementalGroups | indent 4 }}
+{{- end }}
+{{- if .Values.openshift }}
+  openshift: true
+{{- else if eq .Values.openshift false }}
+  openshift: false
+{{- end }}
+{{- if .Values.customTLSSecret }}
+  customTLSSecret:
+{{ toYaml .Values.customTLSSecret | indent 4 }}
+{{- end }}
+{{- if .Values.customReplicationTLSSecret }}
+  customReplicationTLSSecret:
+{{ toYaml .Values.customReplicationTLSSecret | indent 4 }}
+{{- end }}

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -1,19 +1,228 @@
 ---
-# Cluster name
-name: hippo
+# For a full explanation of how to set up the custom resource, please refer to
+# the documentation:
+#    https://access.crunchydata.com/documentation/postgres-operator/v5/
 
-# postgresVersion should match the version of Potsgres you are deploying from
-# the image. This defaults to the below value.
+###########
+# General #
+###########
+
+# name is the name of the cluster. This defaults to the name of the Helm
+# release.
+# name: hippo
+
+# postgresVersion sets the version to deploy. This version number needs to be
+# available as one of the "RELATED_IMAGE_POSTGRES_..." images as part of the PGO
+# installation if you want to deploy the image without setting the "postgres"
+# image variable. This defaults to the below value.
 # postgresVersion: 13
 
-# postgres can be a Postgres or GIS-enabled Postgres image. This defaults to the
-# below value
-# postgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+# postGISVersion if sets and coupled with a PostGIS enabled container, enables
+# PostGIS. This version number needs to be available as one of the
+# "RELATED_IMAGE_POSTGRES_..." images as part of the PGO installation if you
+# want to deploy the image without setting the "postgres" image variable.
+# postGISVersion: 3.1
 
-# pgBackRest is the pgBackRest backup utility image. This defaults to the below
-# value
-# pgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+# NOTE: pgBackRest is enabled by default. It must be set in
+# "RELATED_IMAGE_PGBACKREST" on the PGO deployment, otherwise you will need to
+# override the "pgBackRest" image.
 
-# pgBouncer is the image for the PgBouncer connection pooler. This defaults to
-# the below value
-# pgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+# pgBouncerReplicas sets the number of pgBouncer instances to deploy. The
+# default is 0. You need to set this to at least 1 to deploy pgBouncer or set
+# "pgBouncerConfig". Setting "pgBouncerConfig" will override the value of
+# pgBouncerReplicas. The "RELATED_IMAGE_PGBOUNCER" in the PGO deployment must be
+# set if you want to enable this without explicitly setting "pgBouncer".
+# pgBouncerReplicas: 1
+
+# monitoring enables the ability to monitor the Postgres cluster through a
+# metrics exporter than can be scraped by Prometheus. This defaults to the value
+# below.
+# monitoring: false
+
+###################
+# Image Overrides #
+###################
+
+# imagePostgres can be a Postgres or GIS-enabled Postgres image. This defaults to the
+# below value. "postgresVersion" needs to match the version of Postgres that is
+# used here. If using the GIS-enabled Postgres image, you need to ensure
+# "postGISVersion" matches the version of PostGIS used.
+# imagePostgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+
+# imagePgBackRest is the pgBackRest backup utility image. This defaults to the
+# below value.
+# imagePgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+
+# imagePgBouncer is the image for the PgBouncer connection pooler. This defaults
+# to the below value.
+# imagePgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+
+# imageExporter is the image name for the exporter used as a part of monitoring.
+# This defaults to the value below.
+# imageExporter: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.3-0
+
+###########################
+# Basic Postgres Settings #
+###########################
+
+# instanceName lets you set the name of your instances. This defaults to
+# the value below. Setting "instances" overrides this value.
+# instanceName: instance1
+
+# instanceSize sets the size of the volume that contains the data. This defaults
+# to the value below. Settings "instances" overrides this value.
+# instanceSize: 1Gi
+
+# instanceMemory sets the memory limit for the Postgres instances. This defaults
+# to no limit being set, but an example value is set below. Settings "instances"
+# overrides this value.
+# instanceMemory: 2Gi
+
+# instanceCPU sets the CPU limit for the Postgres instances. This defaults to
+# no limit being set, but an example value is set below. Setting "instances"
+# overrides this value.
+# instanceCPU: 1000m
+
+# instanceReplicas lets you set the total number of Postgres replicas. This
+# defaults to the value below. More than on replica enables high availability
+# (HA). Settings "instances" overrides this value.
+# instanceReplicas: 1
+
+##############################
+# Advanced Postgres Settings #
+##############################
+
+# instances allows you to define one or more Postgres instance sets. By default,
+# PGO will only deploy a single instance. Each instance set has similar
+# characteristics to the other instances in the set, e.g. storage size, resource
+# etc. You can have multiple replicas within an instance set.
+#
+# This allows you to fully customize the topology of your Postgres instances.
+#
+# For example, to set up an instance set with HA (due to the default pod
+# topology spread constraints)
+#
+# instances:
+#   - name: pgha1
+#     replicas: 2
+#     dataVolumeClaimSpec:
+#       accessModes:
+#       - "ReadWriteOnce"
+#       resources:
+#         requests:
+#           storage: 1Gi
+# instances: {}
+
+# port sets the port that Postgres listens on. Defaults to 5432.
+# port: 5432
+
+# patroni lets you set the Patroni configuration for the Postgres cluster.
+# for example, to set up synchronous replication:
+# patroni:
+#   dynamicConfiguration:
+#     synchronous_mode: true
+#     postgresql:
+#       parameters:
+#         synchronous_commit: "on"
+# patroni: {}
+
+# users sets any custom Postgres users and databases that they have  access to
+# as well as any permossions assoicated with the user account.
+# users: {}
+
+# dataSource specifies a data source for bootstrapping a Postgres cluster.
+# dataSource: {}
+
+# customTLSSecret references a Secret that contains the relevant information for
+# bringing external TLS artifacts to a PostgreSQL cluster. This provides the
+# TLS for the cluster itself.
+# customTLSSecret: {}
+
+# customReplicationTLSSecret references a Secret that contains the relevant
+# information for bringing external TLS artifacts to a PostgreSQL cluster. This
+# provides the information for the replication user.
+# customReplicationTLSSecret: {}
+
+# databaseInitSQL referencs a ConfigMap that contains a SQL file that should be
+# run a cluster bootstrap.
+# databaseInitSQL:
+#   name: bootstrap-sql
+#   key: bootstrap.sql
+
+# standby sets whether or not to run this as a standby cluster. Both of the
+# values below are required to enable a standby cluster. Setting "enabled" to
+# "true" eunables the standby cluster while "repoName" points to a pgBackRest
+# archive to replay WAL files from.
+# standby:
+#   enabled: false
+#   repoName: repo1
+
+# shutdown when set scales the entire workload to zero. By default this is not
+# set.
+# shutdown: true
+
+#################################
+# Backups / pgBackRest Settings #
+#################################
+
+# backupsSize sets the storage size of the backups to a PVC. This can be
+# overridden by "pgBackRestConfig", if set. Defaults to the value velow.
+# backupsSize: 1Gi
+
+# pgBackRestConfig allows for the configuration of every pgBackRest option
+# except for "image", which is set by "pgBackRest".
+# pgBackRestConfig: {}
+
+################################
+# Pooling / pgBouncer Settings #
+################################
+
+# pgBouncerConfig sets all of the pgBouncer portion of the spec except for
+# image. To set image, you need to set the "pgBouncer" setting.
+# pgBouncerConfig: {}
+
+#######################
+# Monitoring Settings #
+#######################
+
+# monitoringConfig sets all of the monitoring portion of the spec except for the
+# image. To set the image, which also enables monitoring, you need to set the
+# "monitoring" setting.
+# monitoringConfig: {}
+
+#######################
+# Kubernetes Settings #
+#######################
+
+# metadata contains any metadata that should be applied to all PGO managed
+# objects in this Postgres cluster. This includes "annotations" and "labels" as
+# subkeys.
+# metadata: {}
+
+# service customizes the Service that exposes the Postgres primary.
+# service: {}
+
+# imagePullPolicy sets the pull policy for all the images. This defaults to
+# the Kubernetes heuristic:
+# https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+# imagePullPolicy: IfNotPresent
+
+# imagePullSecrets references Secrets that credentials for pulling image from
+# private repositories
+# imagePullSecrets: []
+
+# supplementalGroups sets any group IDs that should be assigned to
+# Pods, particularly around file system contraints within a system
+# supplementalGroups: []
+
+# disableDefaultPodScheduling if set to true, will disable any of the default
+# scheduling constraints for Pods, such as the default Pod Topology Spread
+# Constraints. If set to false or unset, the default scheduling constraints will
+# be used in addition to any customizations that are added in.
+# disableDefaultPodScheduling: false
+
+# openshift can set explicitly if this is an OpenShift cluster, or a cluster
+# that uses a SecurityContextConstraint. This usually does not need to be set,
+# but you may want to explicitly set it to "false" when using a SCC like
+# "anyuid"
+# openshift: false

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -2,11 +2,18 @@
 # Cluster name
 name: hippo
 
-# PostgreSQL Version
-# Version should match version defined in PostgreSQL images
-postgresVersion: 13
+# postgresVersion should match the version of Potsgres you are deploying from
+# the image. This defaults to the below value.
+# postgresVersion: 13
 
-# Images
-postgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
-pgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
-pgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+# postgres can be a Postgres or GIS-enabled Postgres image. This defaults to the
+# below value
+# postgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+
+# pgBackRest is the pgBackRest backup utility image. This defaults to the below
+# value
+# pgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+
+# pgBouncer is the image for the PgBouncer connection pooler. This defaults to
+# the below value
+# pgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3


### PR DESCRIPTION
 This makes it possible to customize every attribute of deploying
    a Postgres cluster. There are some attributes that are simplified
    for basic installs, while allowing for full flexibility of the
    chart.