### PR TITLE
Create Helm template for quickstart with S3/GCS/Azure + multi-repo

### DIFF
--- a/helm/postgres/templates/_azure.tpl
+++ b/helm/postgres/templates/_azure.tpl
@@ -1,0 +1,12 @@
+{{/* Allow for Azure secret information to be stored in a Secret */}}
+{{- define "postgres.azure" }}
+[global]
+{{- if .azure }}
+  {{- if .azure.account }}
+repo{{ add .index 1 }}-azure-account={{ .azure.account }}
+  {{- end }}
+  {{- if .azure.key }}
+repo{{ add .index 1 }}-azure-key={{ .azure.key }}
+  {{- end }}
+{{- end }}
+{{ end }}

--- a/helm/postgres/templates/_gcs.tpl
+++ b/helm/postgres/templates/_gcs.tpl
@@ -1,0 +1,7 @@
+{{/* Allow for GCS secret information to be stored in a Secret */}}
+{{- define "postgres.gcs" }}
+[global]
+{{- if .gcs }}
+repo{{ add .index 1 }}-gcs-key=/etc/pgbackrest/conf.d/gcs-key.json
+{{- end }}
+{{ end }}

--- a/helm/postgres/templates/_s3.tpl
+++ b/helm/postgres/templates/_s3.tpl
@@ -1,0 +1,15 @@
+{{/* Allow for S3 secret information to be stored in a Secret */}}
+{{- define "postgres.s3" }}
+[global]
+{{- if .Values.s3 }}
+{{- if .Values.s3.key }}
+repo1-s3-key={{ .Values.s3.key }}
+{{- end }}
+{{- if .Values.s3.keySecret }}
+repo1-s3-key-secret={{ .Values.s3.keySecret }}
+{{- end }}
+{{- if .Values.s3.encryptionPassphrase }}
+repo1-cipher-pass={{ .Values.s3.encryptionPassphrase }}
+{{- end }}
+{{- end }}
+{{ end }}

--- a/helm/postgres/templates/_s3.tpl
+++ b/helm/postgres/templates/_s3.tpl
@@ -1,15 +1,15 @@
 {{/* Allow for S3 secret information to be stored in a Secret */}}
 {{- define "postgres.s3" }}
 [global]
-{{- if .Values.s3 }}
-{{- if .Values.s3.key }}
-repo1-s3-key={{ .Values.s3.key }}
-{{- end }}
-{{- if .Values.s3.keySecret }}
-repo1-s3-key-secret={{ .Values.s3.keySecret }}
-{{- end }}
-{{- if .Values.s3.encryptionPassphrase }}
-repo1-cipher-pass={{ .Values.s3.encryptionPassphrase }}
-{{- end }}
+{{- if .s3 }}
+  {{- if .s3.key }}
+repo{{ add .index 1 }}-s3-key={{ .s3.key }}
+  {{- end }}
+  {{- if .s3.keySecret }}
+repo{{ add .index 1 }}-s3-key-secret={{ .s3.keySecret }}
+  {{- end }}
+  {{- if .s3.encryptionPassphrase }}
+repo{{ add .index 1 }}-cipher-pass={{ .s3.encryptionPassphrase }}
+  {{- end }}
 {{- end }}
 {{ end }}

--- a/helm/postgres/templates/pgbackrest-secret.yaml
+++ b/helm/postgres/templates/pgbackrest-secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.s3 }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
+type: Opaque
+data:
+  s3.conf: |-
+        {{ include "postgres.s3" . | b64enc }}
+{{- end }}

--- a/helm/postgres/templates/pgbackrest-secret.yaml
+++ b/helm/postgres/templates/pgbackrest-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.multiBackupRepos .Values.s3 .Values.gcs }}
+{{- if or .Values.multiBackupRepos .Values.s3 .Values.gcs .Values.azure }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -17,6 +17,10 @@ data:
         {{ include "postgres.gcs" $args | b64enc }}
   gcs-key.json: |-
         {{ $repo.gcs.key | b64enc }}
+  {{- else if $repo.azure }}
+  {{- $args := dict "azure" $repo.azure "index" $index }}
+  azure.conf: |-
+        {{ include "postgres.azure" $args | b64enc }}
   {{- end }}
 {{- end }}
 {{- else if .Values.s3 }}
@@ -29,5 +33,9 @@ data:
         {{ include "postgres.gcs" $args | b64enc }}
   gcs-key.json: |-
         {{ .Values.gcs.key | b64enc }}
+{{- else if .Values.azure }}
+  {{- $args := dict "azure" .Values.azure "index" 0 }}
+  azure.conf: |-
+        {{ include "postgres.azure" $args | b64enc }}
 {{- end }}
 {{- end }}

--- a/helm/postgres/templates/pgbackrest-secret.yaml
+++ b/helm/postgres/templates/pgbackrest-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.multiBackupRepos .Values.s3 }}
+{{- if or .Values.multiBackupRepos .Values.s3 .Values.gcs }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,11 +11,23 @@ data:
   {{- $args := dict "s3" $repo.s3 "index" $index }}
   s3.conf: |-
         {{ include "postgres.s3" $args | b64enc }}
+  {{- else if $repo.gcs }}
+  {{- $args := dict "gcs" $repo.gcs "index" $index }}
+  gcs.conf: |-
+        {{ include "postgres.gcs" $args | b64enc }}
+  gcs-key.json: |-
+        {{ $repo.gcs.key | b64enc }}
   {{- end }}
 {{- end }}
 {{- else if .Values.s3 }}
   {{- $args := dict "s3" .Values.s3 "index" 0 }}
   s3.conf: |-
         {{ include "postgres.s3" $args | b64enc }}
+{{- else if .Values.gcs }}
+  {{- $args := dict "gcs" .Values.gcs "index" 0 }}
+  gcs.conf: |-
+        {{ include "postgres.gcs" $args | b64enc }}
+  gcs-key.json: |-
+        {{ .Values.gcs.key | b64enc }}
 {{- end }}
 {{- end }}

--- a/helm/postgres/templates/pgbackrest-secret.yaml
+++ b/helm/postgres/templates/pgbackrest-secret.yaml
@@ -1,10 +1,21 @@
-{{- if .Values.s3 }}
+{{- if or .Values.multiBackupRepos .Values.s3 }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
 type: Opaque
 data:
+{{- if .Values.multiBackupRepos }}
+  {{- range $index, $repo := .Values.multiBackupRepos }}
+  {{- if $repo.s3 }}
+  {{- $args := dict "s3" $repo.s3 "index" $index }}
   s3.conf: |-
-        {{ include "postgres.s3" . | b64enc }}
+        {{ include "postgres.s3" $args | b64enc }}
+  {{- end }}
+{{- end }}
+{{- else if .Values.s3 }}
+  {{- $args := dict "s3" .Values.s3 "index" 0 }}
+  s3.conf: |-
+        {{ include "postgres.s3" $args | b64enc }}
+{{- end }}
 {{- end }}

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -40,6 +40,21 @@ spec:
 {{- end }}
 {{- if .Values.pgBackRestConfig }}
 {{ toYaml .Values.pgBackRestConfig | indent 6 }}
+{{- else if .Values.s3 }}
+      configuration:
+      - secret:
+          name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
+      global:
+        repo1-path: /pgbackrest/{{ .Release.Namespace }}/{{ default .Release.Name .Values.name }}/repo1
+{{- if .Values.s3.encryptionPassphrase }}
+        repo1-cipher-type: aes-256-cbc
+{{- end }}
+      repos:
+      - name: repo1
+        s3:
+          bucket: {{ .Values.s3.bucket | quote }}
+          endpoint: {{ .Values.s3.endpoint | quote }}
+          region: {{ .Values.s3.region | quote }}
 {{- else }}
       repos:
       - name: repo1

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -46,7 +46,7 @@ spec:
           name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
       global:
         {{- range $index, $repo := .Values.multiBackupRepos }}
-        {{- if $repo.s3 }}
+        {{- if or $repo.s3 $repo.gcs }}
         repo{{ add $index 1 }}-path: /pgbackrest/{{ $.Release.Namespace }}/{{ default $.Release.Name $.Values.name }}/repo{{ add $index 1 }}
         {{- end }}
         {{- end }}
@@ -66,6 +66,9 @@ spec:
           bucket: {{ $repo.s3.bucket | quote }}
           endpoint: {{ $repo.s3.endpoint | quote }}
           region: {{ $repo.s3.region | quote }}
+        {{- else if $repo.gcs }}
+        gcs:
+          bucket: {{ $repo.gcs.bucket | quote }}
         {{- end }}
       {{- end }}
 {{- else if .Values.s3 }}
@@ -83,6 +86,16 @@ spec:
           bucket: {{ .Values.s3.bucket | quote }}
           endpoint: {{ .Values.s3.endpoint | quote }}
           region: {{ .Values.s3.region | quote }}
+{{- else if .Values.gcs }}
+      configuration:
+      - secret:
+          name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
+      global:
+        repo1-path: /pgbackrest/{{ .Release.Namespace }}/{{ default .Release.Name .Values.name }}/repo1
+      repos:
+      - name: repo1
+        gcs:
+          bucket: {{ .Values.gcs.bucket | quote }}
 {{- else }}
       repos:
       - name: repo1

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -46,7 +46,7 @@ spec:
           name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
       global:
         {{- range $index, $repo := .Values.multiBackupRepos }}
-        {{- if or $repo.s3 $repo.gcs }}
+        {{- if or $repo.s3 $repo.gcs $repo.azure }}
         repo{{ add $index 1 }}-path: /pgbackrest/{{ $.Release.Namespace }}/{{ default $.Release.Name $.Values.name }}/repo{{ add $index 1 }}
         {{- end }}
         {{- end }}
@@ -69,6 +69,9 @@ spec:
         {{- else if $repo.gcs }}
         gcs:
           bucket: {{ $repo.gcs.bucket | quote }}
+        {{- else if $repo.azure }}
+        azure:
+          container: {{ $repo.azure.container | quote }}
         {{- end }}
       {{- end }}
 {{- else if .Values.s3 }}
@@ -96,6 +99,16 @@ spec:
       - name: repo1
         gcs:
           bucket: {{ .Values.gcs.bucket | quote }}
+{{- else if .Values.azure }}
+      configuration:
+      - secret:
+          name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
+      global:
+        repo1-path: /pgbackrest/{{ .Release.Namespace }}/{{ default .Release.Name .Values.name }}/repo1
+      repos:
+      - name: repo1
+        azure:
+          container: {{ .Values.azure.container | quote }}
 {{- else }}
       repos:
       - name: repo1

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -40,6 +40,34 @@ spec:
 {{- end }}
 {{- if .Values.pgBackRestConfig }}
 {{ toYaml .Values.pgBackRestConfig | indent 6 }}
+{{- else if .Values.multiBackupRepos }}
+      configuration:
+      - secret:
+          name: {{ default .Release.Name .Values.name }}-pgbackrest-secret
+      global:
+        {{- range $index, $repo := .Values.multiBackupRepos }}
+        {{- if $repo.s3 }}
+        repo{{ add $index 1 }}-path: /pgbackrest/{{ $.Release.Namespace }}/{{ default $.Release.Name $.Values.name }}/repo{{ add $index 1 }}
+        {{- end }}
+        {{- end }}
+      repos:
+      {{- range $index, $repo := .Values.multiBackupRepos }}
+      - name: repo{{ add $index 1 }}
+        {{- if $repo.volume }}
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: {{ default "1Gi" $repo.volume.backupsSize | quote }}
+        {{- else if $repo.s3 }}
+        s3:
+          bucket: {{ $repo.s3.bucket | quote }}
+          endpoint: {{ $repo.s3.endpoint | quote }}
+          region: {{ $repo.s3.region | quote }}
+        {{- end }}
+      {{- end }}
 {{- else if .Values.s3 }}
       configuration:
       - secret:

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -189,6 +189,17 @@
 #   # built-in encrpytion system.
 #   encryptionPassphrase: ""
 
+# gcs allows for Google Cloud Storage (GCS) to be used for backups. This allows
+# for a quick setup with GCS; if you need a more advanced setup, use
+# "pgBackRestConfig".
+# gcs:
+#   # bucket is the name of the GCS bucket that the backups will be stored in.
+#   bucket: ""
+#   # key is a multi-line string that contains the GCS key, which is a JSON
+#   # structure.
+#   key: |
+#     {}
+
 # multiBackupRepos allows for backing up to multiple repositories. This is
 # effectively uses the "quickstarts" for each of the backup types (volume, s3,
 # gcs, azure). You can have any permutation of these types. You can set up to 4.
@@ -209,6 +220,10 @@
 #     region: ""
 #     key: ""
 #     keySecret: ""
+# - gcs:
+#     bucket: ""
+#     key: |
+#       {}
 
 # pgBackRestConfig allows for the configuration of every pgBackRest option
 # except for "image", which is set by "pgBackRest".

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -169,6 +169,26 @@
 # overridden by "pgBackRestConfig", if set. Defaults to the value velow.
 # backupsSize: 1Gi
 
+# s3 allows for AWS S3 or an S3 compatible storage system to be used for
+# backups. This allows for a quick setup with S3; if you need more advanced
+# setup, use pgBackRestConfig.
+# s3:
+#   # bucket specifies the S3 bucket to use,
+#   bucket: ""
+#   # endpoint specifies the S3 endpoint to use.
+#   endpoint: ""
+#   # region specifies the S3 region to use. If your S3 storage system does not
+#   # use "region", fill this in with a random vaule.
+#   region: ""
+#   # key is the S3 key. This is stored in a Secret.
+#   key: ""
+#   # keySecret is the S3 key secret. This is tored in a Secret.
+#   keySecret: ""
+#   # encryptionPassphrase is an optional parameter to enable encrypted backups
+#   # with pgBackRest. This is encrypted by pgBackRest and does not use S3's
+#   # built-in encrpytion system.
+#   encryptionPassphrase: ""
+
 # pgBackRestConfig allows for the configuration of every pgBackRest option
 # except for "image", which is set by "pgBackRest".
 # pgBackRestConfig: {}

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -165,8 +165,8 @@
 # Backups / pgBackRest Settings #
 #################################
 
-# backupsSize sets the storage size of the backups to a PVC. This can be
-# overridden by "pgBackRestConfig", if set. Defaults to the value velow.
+# backupsSize sets the storage size of the backups to a volume in Kubernetes.
+# can be overridden by "pgBackRestConfig", if set. Defaults to the value velow.
 # backupsSize: 1Gi
 
 # s3 allows for AWS S3 or an S3 compatible storage system to be used for
@@ -188,6 +188,27 @@
 #   # with pgBackRest. This is encrypted by pgBackRest and does not use S3's
 #   # built-in encrpytion system.
 #   encryptionPassphrase: ""
+
+# multiBackupRepos allows for backing up to multiple repositories. This is
+# effectively uses the "quickstarts" for each of the backup types (volume, s3,
+# gcs, azure). You can have any permutation of these types. You can set up to 4.
+# can be overwritten by "pgBackRestConfig".
+#
+# You can't set "multiBackupRepos" and any of the individual quickstarts at the
+# same time. "multiBackupRepos" will take precedence.
+#
+# Below is an example that enables one of each backup type. Note all of the
+# available quickstart options are presented below; please see the backup types
+# if you want to see how each option works.
+# multiBackupRepos:
+# - volume:
+#     backupsSize: 1Gi
+# - s3:
+#     bucket: ""
+#     endpoint: ""
+#     region: ""
+#     key: ""
+#     keySecret: ""
 
 # pgBackRestConfig allows for the configuration of every pgBackRest option
 # except for "image", which is set by "pgBackRest".

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -200,6 +200,17 @@
 #   key: |
 #     {}
 
+# azure allows for Azure Blob Storage to be used for backups. This allows
+# for a quick setup with Azure Blob Storage; if you need a more advanced setup,
+# use "pgBackRestConfig".
+# azure:
+#   # account is the name of the Azure account to be used.
+#   account: ""
+#   # key is the Secret key used associated with the Azure acount.
+#   key: ""
+#   # container is the Azure container that the backups will be stored in.
+#   container: ""
+
 # multiBackupRepos allows for backing up to multiple repositories. This is
 # effectively uses the "quickstarts" for each of the backup types (volume, s3,
 # gcs, azure). You can have any permutation of these types. You can set up to 4.
@@ -224,6 +235,10 @@
 #     bucket: ""
 #     key: |
 #       {}
+# - azure:
+#     account: ""
+#     key: ""
+#     container: ""
 
 # pgBackRestConfig allows for the configuration of every pgBackRest option
 # except for "image", which is set by "pgBackRest".


### PR DESCRIPTION
This makes it easier to get set up with using S3, GCS, and Azure via the Postgres
Helm chart.

This also adds support for storing backups in multiple repositories.

closes #20