### PR TITLE
Add missing Container Security Context to Helm Chart

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pgo
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 5.0.3

--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -29,4 +29,8 @@ spec:
         - name: PGO_TARGET_NAMESPACE
           valueFrom: { fieldRef: { apiVersion: v1, fieldPath: metadata.namespace } }
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
       serviceAccount: {{ include "install.serviceAccountName" . }}


### PR DESCRIPTION
It is already part of Kustomize based installation

Close #54

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>