### PR TITLE
Ensure PGO image can be overridden in Helm

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pgo
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 5.0.3

--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: operator
-        image: "{{ .Values.image.repository }}/postgres-operator:{{ .Values.image.tag }}"
+        image: "{{ .Values.image.image }}"
         env:
         - name: CRUNCHY_DEBUG
           value: "true"

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -1,8 +1,7 @@
 ---
 ## Provide image repository and tag
 image:
-  repository: registry.developers.crunchydata.com/crunchydata
-  tag: ubi8-5.0.3-0
+  image: registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.0.3-0
 
 relatedImages:
   postgres_14:


### PR DESCRIPTION
This has the PGO image match the same format of the other
related images that can be loaded in via Helm.

close #36

----
There is ongoing discussion if the naming will change again per #52. The aim of this patch is to match our current image override format.