### PR TITLE
Add switch to enable/disable debug mode

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pgo
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 5.0.3

--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -19,8 +19,10 @@ spec:
       - name: operator
         image: "{{ .Values.image.image }}"
         env:
+        {{- if .Values.debug.enabled }}
         - name: CRUNCHY_DEBUG
           value: "true"
+        {{- end }}
         {{- range  $image_name, $image_val := .Values.relatedImages }}
         - name: RELATED_IMAGE_{{ $image_name | upper }}
           value: "{{ $image_val.image }}"

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -1,4 +1,8 @@
 ---
+## Switch to enable/disable debug on Postgres Operator
+debug:
+  enabled: true
+
 ## Provide image repository and tag
 image:
   image: registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.0.3-0


### PR DESCRIPTION
As of now, it is only being used in the Operator
to enable debug logging but based on the variable
name I assume later it can be used not just to
controll the logger level

close #58

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>