### PR TITLE
Allow for "debug" log toggling in Helm installer

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: pgo
-description: A Helm chart for Kubernetes
+description: Installer for PGO, the open source Postgres Operator from Crunchy Data
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 5.0.4

--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -20,7 +20,7 @@ spec:
         image: "{{ .Values.image.image }}"
         env:
         - name: CRUNCHY_DEBUG
-          value: "true"
+          value: {{ if eq .Values.debug false  }}"false"{{- else }}"true"{{- end }}
         {{- range  $image_name, $image_val := .Values.relatedImages }}
         - name: RELATED_IMAGE_{{ $image_name | upper }}
           value: "{{ $image_val.image }}"

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -21,3 +21,7 @@ relatedImages:
 
 ## Install in default or single namespace mode
 singleNamespace: false
+
+# debug allows you to enable or disable the "debug" level of logging.
+# Defaults to the value below.
+# debug: true

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -19,8 +19,11 @@ relatedImages:
   pgexporter:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0
 
-## Install in default or single namespace mode
-singleNamespace: false
+# singleNamespace determines how to install PGO to watch namesapces. If set to
+# false, PGO will watch for Postgres clusters in all namesapces Setting to
+# "true" will instruct PGO to only watch for Postgres clusters in the namespace
+# that it is installed in.
+# singleNamespace: false
 
 # debug allows you to enable or disable the "debug" level of logging.
 # Defaults to the value below.


### PR DESCRIPTION
This adds an attribute for debug logging (debug) to toggle
debug level logging from Helm.

Co-authored-by: Alex Szakaly <alex.szakaly@gmail.com>
close #58