### PR TITLE
Add updated RBAC for PodDisruptionBudgets 

### DIFF
--- a/helm/install/templates/role.yaml
+++ b/helm/install/templates/role.yaml
@@ -90,6 +90,17 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - postgres-operator.crunchydata.com
   resources:
   - postgresclusters

--- a/kustomize/install/bases/rbac/cluster/role.yaml
+++ b/kustomize/install/bases/rbac/cluster/role.yaml
@@ -89,6 +89,17 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - postgres-operator.crunchydata.com
   resources:
   - postgresclusters

--- a/kustomize/install/bases/rbac/namespace/role.yaml
+++ b/kustomize/install/bases/rbac/namespace/role.yaml
@@ -89,6 +89,17 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - postgres-operator.crunchydata.com
   resources:
   - postgresclusters


### PR DESCRIPTION
This commit updates the installer RBAC to include permissions required to interact with PodDisruptionBudgets.

[sc-12872]