### PR TITLE
Add pgupgrade to related images

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pgo
 description: Installer for PGO, the open source Postgres Operator from Crunchy Data
 type: application
-version: 0.2.3
-appVersion: 5.0.4
+version: 0.2.4
+appVersion: 5.1.0

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -1,25 +1,27 @@
 ---
 ## Provide image repository and tag
 image:
-  image: registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.0.4-0
+  image: registry.developers.crunchydata.com/crunchydata/postgres-operator:ubi8-5.1.0-0
 
 relatedImages:
   postgres_14:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
   postgres_14_gis_3.1:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-14.1-3.1-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-14.1-3.1-1
   postgres_13:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-1
   postgres_13_gis_3.1:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-13.5-3.1-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-13.5-3.1-1
   pgadmin:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:centos8-4.20-0
   pgbackrest:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
   pgbouncer:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-1
   pgexporter:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.1.0-0
+  pgupgrade:
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.1.0-0
 
 # singleNamespace determines how to install PGO to watch namesapces. If set to
 # false, PGO will watch for Postgres clusters in all namesapces Setting to

--- a/helm/postgres/Chart.yaml
+++ b/helm/postgres/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgrescluster
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
-appVersion: 5.0.4
+version: 0.2.2
+appVersion: 5.1.0

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -47,19 +47,19 @@
 # below value. "postgresVersion" needs to match the version of Postgres that is
 # used here. If using the GIS-enabled Postgres image, you need to ensure
 # "postGISVersion" matches the version of PostGIS used.
-# imagePostgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
+# imagePostgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-1
 
 # imagePgBackRest is the pgBackRest backup utility image. This defaults to the
 # below value.
-# imagePgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+# imagePgBackRest: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
 
 # imagePgBouncer is the image for the PgBouncer connection pooler. This defaults
 # to the below value.
-# imagePgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-0
+# imagePgBouncer: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-1
 
 # imageExporter is the image name for the exporter used as a part of monitoring.
 # This defaults to the value below.
-# imageExporter: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0
+# imageExporter: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.1.0-0
 
 ###########################
 # Basic Postgres Settings #

--- a/kustomize/azure/postgres.yaml
+++ b/kustomize/azure/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-azure
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+  postgresVersion: 14
   instances:
     - dataVolumeClaimSpec:
         accessModes:
@@ -14,7 +14,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
       configuration:
       - secret:
           name: pgo-azure-creds

--- a/kustomize/certmanager/postgres/postgres.yaml
+++ b/kustomize/certmanager/postgres/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+  postgresVersion: 14
   customReplicationTLSSecret:
     name: hippo-repl-tls
   customTLSSecret:
@@ -19,7 +19,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
       repos:
       - name: repo1
         volume:

--- a/kustomize/gcs/postgres.yaml
+++ b/kustomize/gcs/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-gcs
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+  postgresVersion: 14
   instances:
     - dataVolumeClaimSpec:
         accessModes:
@@ -14,7 +14,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
       configuration:
       - secret:
           name: pgo-gcs-creds

--- a/kustomize/high-availability/ha-postgres.yaml
+++ b/kustomize/high-availability/ha-postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-ha
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+  postgresVersion: 14
   instances:
     - name: pgha1
       replicas: 2
@@ -26,7 +26,7 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
       repos:
       - name: repo1
         volume:
@@ -38,7 +38,7 @@ spec:
                 storage: 1Gi
   proxy:
     pgBouncer:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-1
       replicas: 2
       affinity:
         podAntiAffinity:

--- a/kustomize/install/bases/kustomization.yaml
+++ b/kustomize/install/bases/kustomization.yaml
@@ -2,7 +2,7 @@ namespace: postgres-operator
 
 commonLabels:
   app.kubernetes.io/name: pgo
-  app.kubernetes.io/version: 5.0.4
+  app.kubernetes.io/version: 5.1.0
   postgres-operator.crunchydata.com/control-plane: postgres-operator
 
 bases:
@@ -13,7 +13,7 @@ bases:
 images:
 - name: postgres-operator
   newName: registry.developers.crunchydata.com/crunchydata/postgres-operator
-  newTag: ubi8-5.0.4-0
+  newTag: ubi8-5.1.0-0
 
 patchesJson6902:
   - target:

--- a/kustomize/install/bases/manager/manager.yaml
+++ b/kustomize/install/bases/manager/manager.yaml
@@ -18,22 +18,24 @@ spec:
               fieldPath: metadata.namespace
         - name: CRUNCHY_DEBUG
           value: "true"
-        - name: RELATED_IMAGE_POSTGRES_14
-          value: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-0
-        - name: RELATED_IMAGE_POSTGRES_14_GIS_3.1
-          value: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-14.1-3.1-0
         - name: RELATED_IMAGE_POSTGRES_13
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-1"
         - name: RELATED_IMAGE_POSTGRES_13_GIS_3.1
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-13.5-3.1-0"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-13.5-3.1-1"
+        - name: RELATED_IMAGE_POSTGRES_14
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1"
+        - name: RELATED_IMAGE_POSTGRES_14_GIS_3.1
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:centos8-14.1-3.1-1"
         - name: RELATED_IMAGE_PGADMIN
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:centos8-4.20-0"
         - name: RELATED_IMAGE_PGBACKREST
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1"
         - name: RELATED_IMAGE_PGBOUNCER
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-0"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.16-1"
         - name: RELATED_IMAGE_PGEXPORTER
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.0.4-0"
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-exporter:ubi8-5.1.0-0"
+        - name: RELATED_IMAGE_PGUPGRADE
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-upgrade:ubi8-5.1.0-0"
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/kustomize/keycloak/postgres.yaml
+++ b/kustomize/keycloak/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: keycloakdb
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+  postgresVersion: 14
   instances:
     - replicas: 2
       dataVolumeClaimSpec:
@@ -25,7 +25,7 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: "00"
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
       repos:
       - name: repo1
         volume:

--- a/kustomize/multi-backup-repo/postgres.yaml
+++ b/kustomize/multi-backup-repo/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-multi-repo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+  postgresVersion: 14
   instances:
     - dataVolumeClaimSpec:
         accessModes:
@@ -14,7 +14,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
       configuration:
       - secret:
           name: pgo-multi-repo-creds

--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+  postgresVersion: 14
   instances:
     - name: instance1
       dataVolumeClaimSpec:
@@ -15,7 +15,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
       repos:
       - name: repo1
         volume:

--- a/kustomize/s3/postgres.yaml
+++ b/kustomize/s3/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-s3
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.5-0
-  postgresVersion: 13
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-14.1-1
+  postgresVersion: 14
   instances:
     - dataVolumeClaimSpec:
         accessModes:
@@ -14,7 +14,7 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-0
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.36-1
       configuration:
       - secret:
           name: pgo-s3-creds


### PR DESCRIPTION
The `crunchy-upgrade` image is used for PostgreSQL major version upgrades.

Issue: [sc-13269]