### PR TITLE
Add postgres-operator RBAC permissions for PDB

### DIFF
--- a/helm/install/templates/role.yaml
+++ b/helm/install/templates/role.yaml
@@ -90,6 +90,17 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - postgres-operator.crunchydata.com
   resources:
   - postgresclusters

--- a/kustomize/install/bases/rbac/cluster/role.yaml
+++ b/kustomize/install/bases/rbac/cluster/role.yaml
@@ -89,6 +89,17 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - postgres-operator.crunchydata.com
   resources:
   - postgresclusters

--- a/kustomize/install/bases/rbac/namespace/role.yaml
+++ b/kustomize/install/bases/rbac/namespace/role.yaml
@@ -89,6 +89,17 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
   - postgres-operator.crunchydata.com
   resources:
   - postgresclusters


### PR DESCRIPTION
CrunchyData/postgres-operator#2828 introduced a feature to reconcile the Pod Disruption Budget (PDB) of PG instance sets. This requires additional API permissions which were added to the RBAC definitions (e.g. [config/rbac/cluster/role.yaml](https://github.com/CrunchyData/postgres-operator/blob/master/config/rbac/cluster/role.yaml)) in the main repository but forgotten here.

Fixes #78 