### PR TITLE
Make the number of controller workers configurable

### DIFF
--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -33,6 +33,10 @@ spec:
         - name: PGO_TARGET_NAMESPACE
           valueFrom: { fieldRef: { apiVersion: v1, fieldPath: metadata.namespace } }
         {{- end }}
+        {{- if .Values.workers }}
+        - name: PGO_WORKERS
+          value: {{ .Values.workers | quote }}
+        {{- end }}
         {{- if (default false .Values.disable_check_for_upgrades) }}
         - name: CHECK_FOR_UPGRADES
           value: "false"


### PR DESCRIPTION
The environment variable is added in https://github.com/CrunchyData/postgres-operator/pull/3028.

```
● helm install --dry-run pgo ./helm/install | grep -A1 WORKERS
# (nothing)

● helm install --dry-run pgo --set workers=0 ./helm/install | grep -A1 WORKERS
# (nothing)

● helm install --dry-run pgo --set workers=1 ./helm/install | grep -A1 WORKERS
        - name: PGO_WORKERS
          value: "1"

● helm install --dry-run pgo --set workers=2 ./helm/install | grep -A1 WORKERS
        - name: PGO_WORKERS
          value: "2"
```

Issue: [sc-11427]