### PR TITLE
Add labels to backup job

### DIFF
--- a/helm/postgres/Chart.yaml
+++ b/helm/postgres/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: postgrescluster
 description: A Helm chart for Kubernetes
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 5.0.4

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -35,6 +35,9 @@ spec:
   {{- end }}
   backups:
     pgbackrest:
+      {{- if .Values.pgBackRestMetadata }}
+      metadata:  {{ toYaml .Values.pgBackRestMetadata | nindent 8 }}
+      {{- end }}
       {{- if .Values.imagePgBackRest }}
       image: {{ .Values.imagePgBackRest | quote }}
       {{- end }}


### PR DESCRIPTION
Option to add labels to the pgbackrest backup job.
mostly added to disable istio side-car injection because the pgbackrest container starts before the envoy proxy.

before:
```
➜  kubectl get po                               
NAME                                      READY   STATUS      RESTARTS   AGE
pg-db-1-backup-tq5j-bqpdb                 1/2     Error       0          16s
pg-db-1-instance1-n6k6-0                  4/4     Running     0          37m
pg-db-1-instance1-vjrl-0                  4/4     Running     0          37m
pg-db-1-instance1-vxzb-0                  4/4     Running     0          37m
pg-db-1-repo-host-0                       2/2     Running     0          37m

➜  kubectl logs pg-db-1-backup-tq5j-8bvqh                         
time="2022-03-01T16:59:01Z" level=info msg="crunchy-pgbackrest starts"
time="2022-03-01T16:59:01Z" level=info msg="debug flag set to false"
time="2022-03-01T16:59:01Z" level=fatal msg="Get \"https://10.43.0.1:443/api/v1/namespaces/zcenter/pods?labelSelector=postgres-operator.crunchydata.com%2Fcluster%3Dpg-db-1%2Cpostgres-operator.crunchydata.com%2Fpgbackrest%3D%2Cpostgres-operator.crunchydata.com%2Fpgbackrest-dedicated%3D\": dial tcp 10.43.0.1:443: connect: connection refused"

```

after:
```
➜  kubectl get po                               
NAME                                      READY   STATUS      RESTARTS   AGE
pg-db-1-backup-wggx-vz77p                 0/1     Completed   0          16m
pg-db-1-instance1-n6k6-0                  4/4     Running     0          86m
pg-db-1-instance1-vjrl-0                  4/4     Running     0          86m
pg-db-1-instance1-vxzb-0                  4/4     Running     0          86m
pg-db-1-repo-host-0                       1/1     Running     0          17m

➜   kubectl logs pg-db-1-backup-wggx-vz77p -f
time="2022-03-01T17:35:16Z" level=info msg="crunchy-pgbackrest starts"
time="2022-03-01T17:35:16Z" level=info msg="debug flag set to false"
time="2022-03-01T17:35:16Z" level=info msg="backrest backup command requested"
time="2022-03-01T17:35:16Z" level=info msg="command to execute is [pgbackrest backup --stanza=db --repo=1]"
time="2022-03-01T17:35:49Z" level=info msg="output=[]"
time="2022-03-01T17:35:49Z" level=info msg="stderr=[WARN: option 'repo1-retention-full' is not set for 'repo1-retention-full-type=count', the repository may run out of space\n      HINT: to retain full backups indefinitely (without warning), set option 'repo1-retention-full' to the maximum.\nWARN: no prior backup exists, incr backup has been changed to full\n]"
time="2022-03-01T17:35:49Z" level=info msg="crunchy-pgbackrest ends"
```