### PR TITLE
Helm Chart fix wrong dataSource key in postgres template

### DIFF
--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -145,7 +145,7 @@ spec:
 {{ toYaml .Values.service | indent 4 }}
   {{- end }}
   {{- if .Values.dataSource }}
-  service:
+  dataSource:
 {{ toYaml .Values.dataSource | indent 4 }}
   {{- end }}
   {{- if .Values.databaseInitSQL }}


### PR DESCRIPTION
The dataSource section in the helm chart postgres template has _service:_ key instead of _dataSource:_