### PR TITLE
Remove the status field from CRD YAML

### DIFF
--- a/helm/install/crds/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/helm/install/crds/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -9409,9 +9409,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/kustomize/install/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/kustomize/install/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -9406,9 +9406,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
Older versions of Kubernetes do not ignore sub-resource fields when using server-side apply.

Issue: [sc-14162]
See: https://github.com/CrunchyData/postgres-operator/pull/3131