### PR TITLE
Granting PDB api access to the pgo clusterrole

### DIFF
--- a/helm/install/templates/role.yaml
+++ b/helm/install/templates/role.yaml
@@ -134,3 +134,13 @@ rules:
   - list
   - patch
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+  - patch
+  - create
+  - get


### PR DESCRIPTION
Swapped to the 5.1.0 operator and ran into issues with the operator not having access to the pdb

E0422 15:07:14.680140       1 reflector.go:138] k8s.io/client-go@v0.20.8/tools/cache/reflector.go:167: Failed to watch *v1beta1.PodDisruptionBudget: failed to list *v1beta1.PodDisruptionBudget: poddisruptionbudgets.policy is forbidden: User "system:serviceaccount:crunchydata:pgo" cannot list resource "poddisruptionbudgets" in API group "policy" at the cluster scope

These permissions resolved the errors.