### PR TITLE
Enable seccomp on containers

### DIFF
--- a/helm/install/templates/manager-upgrade.yaml
+++ b/helm/install/templates/manager-upgrade.yaml
@@ -38,3 +38,5 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault

--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -44,3 +44,5 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault

--- a/kustomize/install/manager/manager-upgrade.yaml
+++ b/kustomize/install/manager/manager-upgrade.yaml
@@ -32,4 +32,6 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       serviceAccountName: postgres-operator-upgrade

--- a/kustomize/install/manager/manager.yaml
+++ b/kustomize/install/manager/manager.yaml
@@ -46,4 +46,6 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
       serviceAccountName: pgo


### PR DESCRIPTION
As of Kubernetes v1.19, SecurityContext has a seccompProfile field
that can be set to RuntimeDefault to limit syscalls.

This PR adds that setting to the PGO containers.

Issue [sc-11286]