### PR TITLE
Revert "Enable seccomp on containers (#122)"

### DIFF
--- a/helm/install/templates/manager-upgrade.yaml
+++ b/helm/install/templates/manager-upgrade.yaml
@@ -38,5 +38,3 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault

--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -44,5 +44,3 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault

--- a/kustomize/install/manager/manager-upgrade.yaml
+++ b/kustomize/install/manager/manager-upgrade.yaml
@@ -32,6 +32,4 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
       serviceAccountName: postgres-operator-upgrade

--- a/kustomize/install/manager/manager.yaml
+++ b/kustomize/install/manager/manager.yaml
@@ -46,6 +46,4 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsNonRoot: true
-          seccompProfile:
-            type: RuntimeDefault
       serviceAccountName: pgo


### PR DESCRIPTION
This reverts commit a7d78aedd889e7c386c704e9a8cfb0f25a278a93.

Removing seccompProfile for compatibility with OpenShift