### PR TITLE
Align Related Images in manager.yaml With OLM

### DIFF
--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -8,10 +8,14 @@ controllerImages:
 relatedImages:
   postgres_14:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.3-0
+  postgres_14_gis_3.1:
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.3-3.1-0
   postgres_14_gis_3.2:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.3-3.2-0
   postgres_13:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.7-0
+  postgres_13_gis_3.0:
+    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.7-3.0-0
   postgres_13_gis_3.1:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.7-3.1-0
   pgadmin:

--- a/kustomize/install/manager/manager.yaml
+++ b/kustomize/install/manager/manager.yaml
@@ -28,10 +28,14 @@ spec:
           value: "true"
         - name: RELATED_IMAGE_POSTGRES_13
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.7-0"
+        - name: RELATED_IMAGE_POSTGRES_13_GIS_3.0
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.7-3.0-0"
         - name: RELATED_IMAGE_POSTGRES_13_GIS_3.1
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.7-3.1-0"
         - name: RELATED_IMAGE_POSTGRES_14
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.3-0"
+        - name: RELATED_IMAGE_POSTGRES_14_GIS_3.1
+          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.3-3.1-0"
         - name: RELATED_IMAGE_POSTGRES_14_GIS_3.2
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.3-3.2-0"
         - name: RELATED_IMAGE_PGADMIN


### PR DESCRIPTION
The related images in the `manager.yaml` file now align with the related images configured for OLM using `related-images.yaml`.

[sc-14517]