### PR TITLE
fix: render to dataSource, not service, when `values.dataSource` is specified

### DIFF
--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -145,7 +145,7 @@ spec:
 {{ toYaml .Values.service | indent 4 }}
   {{- end }}
   {{- if .Values.dataSource }}
-  service:
+  dataSource:
 {{ toYaml .Values.dataSource | indent 4 }}
   {{- end }}
   {{- if .Values.databaseInitSQL }}


### PR DESCRIPTION
Simple fix - `service` seems to be specified accidentally here. It should be `dataSource` .