### PR TITLE
Updating Keycloak example Kustomize manifest

### DIFF
--- a/kustomize/keycloak/keycloak.yaml
+++ b/kustomize/keycloak/keycloak.yaml
@@ -16,6 +16,7 @@ spec:
     spec:
       containers:
       - image: quay.io/keycloak/keycloak:latest
+        args: ["start-dev"]
         name: keycloak
         env:
         - name: DB_VENDOR
@@ -30,12 +31,12 @@ spec:
           valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: user } }
         - name: DB_PASSWORD
           valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: password } }
-        - name: KEYCLOAK_USER
+        - name: KEYCLOAK_ADMIN
           value: "admin"
-        - name: KEYCLOAK_PASSWORD
+        - name: KEYCLOAK_ADMIN_PASSWORD
           value: "admin"
-        - name: PROXY_ADDRESS_FORWARDING
-          value: "true"
+        - name: KC_PROXY
+          value: "edge"
         ports:
         - name: http
           containerPort: 8080
@@ -43,6 +44,6 @@ spec:
           containerPort: 8443
         readinessProbe:
           httpGet:
-            path: /auth/realms/master
+            path: /realms/master
             port: 8080
       restartPolicy: Always


### PR DESCRIPTION
When Keycloak [migrated to Quarkus](https://www.keycloak.org/migration/migrating-to-quarkus) when it hit version 17, a number of changes were made that impacted the Keycloak Kustomize manifest.

- /auth was removed from the default context path (affects the readiness probe path)
- An argument needs to be passed to the container
- The [admin auth](https://www.keycloak.org/server/configuration#_setup_of_the_initial_admin_user) environment variables changed
- The [proxy environment variable](https://www.keycloak.org/server/reverseproxy) changed

This (along with [this corresponding PR](https://github.com/CrunchyData/postgres-operator/pull/3307)) should help fix #116

The readiness probe, argument line addition, and environment variable changes allow the container to fully initialize and begin receiving traffic. The changes roughly match what [Keycloak provides](https://www.keycloak.org/getting-started/getting-started-kube#_run_keycloak) in its [example manifest](https://raw.githubusercontent.com/keycloak/keycloak-quickstarts/latest/kubernetes-examples/keycloak.yaml).