### PR TITLE
Add name and version Labels to CRDs

### DIFF
--- a/helm/install/Chart.yaml
+++ b/helm/install/Chart.yaml
@@ -4,4 +4,5 @@ description: Installer for PGO, the open source Postgres Operator from Crunchy D
 
 type: application
 version: 0.3.2
+# The version below should match the version on the PostgresCluster CRD
 appVersion: 5.1.2

--- a/helm/install/crds/postgres-operator.crunchydata.com_pgupgrades.yaml
+++ b/helm/install/crds/postgres-operator.crunchydata.com_pgupgrades.yaml
@@ -4,10 +4,10 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
-  name: pgupgrades.postgres-operator.crunchydata.com
   labels:
     app.kubernetes.io/name: pgo
     app.kubernetes.io/version: 5.1.2
+  name: pgupgrades.postgres-operator.crunchydata.com
 spec:
   group: postgres-operator.crunchydata.com
   names:

--- a/helm/install/crds/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/helm/install/crds/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -4,10 +4,10 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
-  name: postgresclusters.postgres-operator.crunchydata.com
   labels:
     app.kubernetes.io/name: pgo
     app.kubernetes.io/version: 5.1.2
+  name: postgresclusters.postgres-operator.crunchydata.com
 spec:
   group: postgres-operator.crunchydata.com
   names:

--- a/helm/postgres/Chart.yaml
+++ b/helm/postgres/Chart.yaml
@@ -3,4 +3,5 @@ name: postgrescluster
 description: A Helm chart for Kubernetes
 type: application
 version: 0.2.5
+# The version below should match the version on the PostgresCluster CRD
 appVersion: 5.1.2

--- a/kustomize/install/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
+++ b/kustomize/install/crd/bases/postgres-operator.crunchydata.com_pgupgrades.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: pgo
+    app.kubernetes.io/version: 5.1.2
   name: pgupgrades.postgres-operator.crunchydata.com
 spec:
   group: postgres-operator.crunchydata.com

--- a/kustomize/install/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
+++ b/kustomize/install/crd/bases/postgres-operator.crunchydata.com_postgresclusters.yaml
@@ -4,6 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/name: pgo
+    app.kubernetes.io/version: 5.1.2
   name: postgresclusters.postgres-operator.crunchydata.com
 spec:
   group: postgres-operator.crunchydata.com

--- a/kustomize/install/default/kustomization.yaml
+++ b/kustomize/install/default/kustomization.yaml
@@ -2,6 +2,7 @@ namespace: postgres-operator
 
 commonLabels:
   app.kubernetes.io/name: pgo
+  # The version below should match the version on the PostgresCluster CRD
   app.kubernetes.io/version: 5.1.2
 
 bases:

--- a/kustomize/install/singlenamespace/kustomization.yaml
+++ b/kustomize/install/singlenamespace/kustomization.yaml
@@ -2,6 +2,7 @@ namespace: postgres-operator
 
 commonLabels:
   app.kubernetes.io/name: pgo
+  # The version below should match the version on the PostgresCluster CRD
   app.kubernetes.io/version: 5.1.2
 
 bases:


### PR DESCRIPTION
Adds the name and version labels to CRDs, as needed, to
standardize CRD format across repositories and added comments
to clarify where versions should match.