### PR TITLE
feature: added possibility to define the name of the instance and backup storage class

### DIFF
--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -57,6 +57,7 @@ spec:
         {{- if $repo.volume }}
         volume:
           volumeClaimSpec:
+            {{- if $repo.volume.backupsStorageClassName -}}storageClassName: {{ .Values.backupsStorageClassName | quote }}{{ end }}
             accessModes:
             - "ReadWriteOnce"
             resources:
@@ -115,6 +116,7 @@ spec:
       - name: repo1
         volume:
           volumeClaimSpec:
+            {{- if .Values.backupsStorageClassName -}}storageClassName: {{ .Values.backupsStorageClassName | quote }}{{ end }}
             accessModes:
             - "ReadWriteOnce"
             resources:

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -21,6 +21,7 @@ spec:
     - name: {{ default "instance1" .Values.instanceName | quote }}
       replicas: {{ default 1 .Values.instanceReplicas }}
       dataVolumeClaimSpec:
+        {{- if .Values.storageClassName -}}storageClassName: {{ .Values.storageClassName | quote }}{{ end }}
         accessModes:
         - "ReadWriteOnce"
         resources:

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -116,7 +116,9 @@ spec:
       - name: repo1
         volume:
           volumeClaimSpec:
-            {{- if .Values.backupsStorageClassName -}}storageClassName: {{ .Values.backupsStorageClassName | quote }}{{ end }}
+            {{- if .Values.backupsStorageClassName }}
+            storageClassName: {{ .Values.backupsStorageClassName | quote }}
+            {{- end }}
             accessModes:
             - "ReadWriteOnce"
             resources:

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -57,7 +57,9 @@ spec:
         {{- if $repo.volume }}
         volume:
           volumeClaimSpec:
-            {{- if $repo.volume.backupsStorageClassName -}}storageClassName: {{ .Values.backupsStorageClassName | quote }}{{ end }}
+            {{- if $repo.volume.backupsStorageClassName }}
+            storageClassName: {{ .Values.backupsStorageClassName | quote }}
+            {{- end }}
             accessModes:
             - "ReadWriteOnce"
             resources:

--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -21,7 +21,9 @@ spec:
     - name: {{ default "instance1" .Values.instanceName | quote }}
       replicas: {{ default 1 .Values.instanceReplicas }}
       dataVolumeClaimSpec:
-        {{- if .Values.storageClassName -}}storageClassName: {{ .Values.storageClassName | quote }}{{ end }}
+        {{- if .Values.instanceStorageClassName }}
+        storageClassName: {{ .Values.instanceStorageClassName | quote }}
+        {{- end }}
         accessModes:
         - "ReadWriteOnce"
         resources:

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -175,6 +175,11 @@ postgresVersion: 14
 # can be overridden by "pgBackRestConfig", if set. Defaults to the value below.
 # backupsSize: 1Gi
 
+# backupsStorageClassName sets the storage class to a class existing in Kubernetes.
+# Defaults to the "default" storage class defined in the cluster.
+# Can be overridden by "pgBackRestConfig", if set.
+# backupsStorageClassName: "hostpath"
+
 # s3 allows for AWS S3 or an S3 compatible storage system to be used for
 # backups. This allows for a quick setup with S3; if you need more advanced
 # setup, use pgBackRestConfig.

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -73,6 +73,12 @@ postgresVersion: 14
 # to the value below. Settings "instances" overrides this value.
 # instanceSize: 1Gi
 
+# instanceStorageClassName sets the storage class for the volume that contains the data.
+# This defaults to the "default" storage class defined in the cluster.
+# See: 'kubectl get storageclasses.storage.k8s.io | grep default'
+# Settings "instances" overrides this value.
+# instanceStorageClassName: "hostpath"
+
 # instanceMemory sets the memory limit for the Postgres instances. This defaults
 # to no limit being set, but an example value is set below. Settings "instances"
 # overrides this value.


### PR DESCRIPTION
As part of our customization's to the PostgreSQL cluster, we discovered that it is currently not possible to change the storage class for predefined instances. Since our cluster infrastructure contains more than one storage class with different underlying storage technologies, it is necessary for us to select a specific storage class. We found that this is already possible when we define our own instance, but we thought it would be more useful to simply add this functionality to the chart.