### PR TITLE
Fixed a typo in values.yaml

### DIFF
--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -127,7 +127,7 @@ postgresVersion: 14
 # patroni: {}
 
 # users sets any custom Postgres users and databases that they have  access to
-# as well as any permossions assoicated with the user account.
+# as well as any permissions assoicated with the user account.
 # users: {}
 
 # dataSource specifies a data source for bootstrapping a Postgres cluster.


### PR DESCRIPTION
`helm/postgres/values.yaml` mentioned "permossions" instead of "permissions"