### PR TITLE
Add keyType to postgres s3 helm template

### DIFF
--- a/helm/postgres/templates/_s3.tpl
+++ b/helm/postgres/templates/_s3.tpl
@@ -8,6 +8,9 @@ repo{{ add .index 1 }}-s3-key={{ .s3.key }}
   {{- if .s3.keySecret }}
 repo{{ add .index 1 }}-s3-key-secret={{ .s3.keySecret }}
   {{- end }}
+  {{- if .s3.keyType }}
+repo{{ add .index 1 }}-s3-key-type={{ .s3.keyType }}
+  {{- end }}
   {{- if .s3.encryptionPassphrase }}
 repo{{ add .index 1 }}-cipher-pass={{ .s3.encryptionPassphrase }}
   {{- end }}

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -182,8 +182,10 @@ postgresVersion: 14
 #   region: ""
 #   # key is the S3 key. This is stored in a Secret.
 #   key: ""
-#   # keySecret is the S3 key secret. This is tored in a Secret.
+#   # keySecret is the S3 key secret. This is stored in a Secret.
 #   keySecret: ""
+#   # keyType can be configured to enable IAM integration via AssumeRole
+#   keyType: ""
 #   # encryptionPassphrase is an optional parameter to enable encrypted backups
 #   # with pgBackRest. This is encrypted by pgBackRest and does not use S3's
 #   # built-in encrpytion system.
@@ -231,6 +233,7 @@ postgresVersion: 14
 #     region: ""
 #     key: ""
 #     keySecret: ""
+#     keyType: ""
 # - gcs:
 #     bucket: ""
 #     key: |


### PR DESCRIPTION
keyType was missing from the list of s3 config fields.