### PR TITLE
Adding capability to stream off of a primary when deployed via Helm

### DIFF
--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -191,7 +191,9 @@ spec:
   {{- if .Values.standby }}
   standby:
     enabled: {{ .Values.standby.enabled }}
-    repoName: {{ required "repoName must be set when enabling standby mode." .Values.standby.repoName }}
+    repoName: {{ .Values.standby.repoName }}
+    host: {{ .Values.standby.host }}
+    port: {{ .Values.standby.port }}
   {{- end }}
   {{- if .Values.supplementalGroups }}
   supplementalGroups:

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -163,7 +163,7 @@ postgresVersion: 14
 #   enabled: false
 #   repoName: repo1
 #   host: "192.0.2.2"
-#   port: "5432"
+#   port: 5432
 
 # shutdown when set scales the entire workload to zero. By default this is not
 # set.

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -155,16 +155,15 @@ postgresVersion: 14
 #   name: bootstrap-sql
 #   key: bootstrap.sql
 
-# standby sets whether or not to run this as a standby cluster. Both of the
-# values below are required to enable a standby cluster. Setting "enabled" to
+# standby sets whether or not to run this as a standby cluster. Setting "enabled" to
 # "true" eunables the standby cluster while "repoName" points to a pgBackRest
 # archive to replay WAL files from, and "host" and "port" point to a primary
 # cluster from which to stream data.
 # standby:
 #   enabled: false
 #   repoName: repo1
-#   host: "<primary-ip>"
-#   port: "<primary-port>"
+#   host: "192.0.2.2"
+#   port: "5432"
 
 # shutdown when set scales the entire workload to zero. By default this is not
 # set.

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -158,10 +158,13 @@ postgresVersion: 14
 # standby sets whether or not to run this as a standby cluster. Both of the
 # values below are required to enable a standby cluster. Setting "enabled" to
 # "true" eunables the standby cluster while "repoName" points to a pgBackRest
-# archive to replay WAL files from.
+# archive to replay WAL files from, and "host" and "port" point to a primary
+# cluster from which to stream data.
 # standby:
 #   enabled: false
 #   repoName: repo1
+#   host: "<primary-ip>"
+#   port: "<primary-port>"
 
 # shutdown when set scales the entire workload to zero. By default this is not
 # set.


### PR DESCRIPTION
Since the operator now supports [standby clusters with streaming replication](https://access.crunchydata.com/documentation/private/postgres-operator-private/5.3.0/tutorial/disaster-recovery/index.html#streaming-standby), support for this ought to be built into the postgres Helm chart.