### PR TITLE
Backpatch: Adding capability to stream off of a primary when deployed via Helm

### DIFF
--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -182,7 +182,9 @@ spec:
   {{- if .Values.standby }}
   standby:
     enabled: {{ .Values.standby.enabled }}
-    repoName: {{ required "repoName must be set when enabling standby mode." .Values.standby.repoName }}
+    repoName: {{ .Values.standby.repoName }}
+    host: {{ .Values.standby.host }}
+    port: {{ .Values.standby.port }}
   {{- end }}
   {{- if .Values.supplementalGroups }}
   supplementalGroups:

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -149,13 +149,15 @@ postgresVersion: 14
 #   name: bootstrap-sql
 #   key: bootstrap.sql
 
-# standby sets whether or not to run this as a standby cluster. Both of the
-# values below are required to enable a standby cluster. Setting "enabled" to
+# standby sets whether or not to run this as a standby cluster. Setting "enabled" to
 # "true" eunables the standby cluster while "repoName" points to a pgBackRest
-# archive to replay WAL files from.
+# archive to replay WAL files from, and "host" and "port" point to a primary
+# cluster from which to stream data.
 # standby:
 #   enabled: false
 #   repoName: repo1
+#   host: "192.0.2.2"
+#   port: 5432
 
 # shutdown when set scales the entire workload to zero. By default this is not
 # set.


### PR DESCRIPTION
Adding capability to stream off of a primary when deployed via Helm (#185)

* Adding capability to stream off of a primary due to feature addition in PGOv5.3, removing requirement to specify a repo when standby is enabled.

* Removing outdated comment about required standby values and specifying more realistic values for host and port.

* Changing port value to an integer

Issue: [sc-17928]