### PR TITLE
Removed Postgres 13 from RELATED_IMAGE. 

### DIFF
--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -18,12 +18,6 @@ relatedImages:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.7-3.2-0
   postgres_14_gis_3.3:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-14.7-3.3-0
-  postgres_13:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.10-0
-  postgres_13_gis_3.0:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.10-3.0-0
-  postgres_13_gis_3.1:
-    image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.10-3.1-0
   pgadmin:
     image: registry.developers.crunchydata.com/crunchydata/crunchy-pgadmin4:ubi8-4.30-10
   pgbackrest:

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -47,7 +47,7 @@ postgresVersion: 14
 # below value. "postgresVersion" needs to match the version of Postgres that is
 # used here. If using the GIS-enabled Postgres image, you need to ensure
 # "postGISVersion" matches the version of PostGIS used.
-# imagePostgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.10-1
+# imagePostgres: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.7-0
 
 # imagePgBackRest is the pgBackRest backup utility image. This defaults to the
 # below value.

--- a/kustomize/install/manager/manager.yaml
+++ b/kustomize/install/manager/manager.yaml
@@ -26,12 +26,6 @@ spec:
               fieldPath: metadata.namespace
         - name: CRUNCHY_DEBUG
           value: "true"
-        - name: RELATED_IMAGE_POSTGRES_13
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-13.10-0"
-        - name: RELATED_IMAGE_POSTGRES_13_GIS_3.0
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.10-3.0-0"
-        - name: RELATED_IMAGE_POSTGRES_13_GIS_3.1
-          value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres-gis:ubi8-13.10-3.1-0"
         - name: RELATED_IMAGE_POSTGRES_14
           value: "registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-14.7-0"
         - name: RELATED_IMAGE_POSTGRES_14_GIS_3.1


### PR DESCRIPTION
Removed Postgres 13 from RELATED_IMAGE.  Now that we've had 2 patch releases of Postgres 15 we are dropping postgres 13.

Issue [sc-17907]