### PR TITLE
Allow user to provide pod labels via values.yaml

### DIFF
--- a/helm/install/templates/_helpers.tpl
+++ b/helm/install/templates/_helpers.tpl
@@ -26,6 +26,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
+Custom Labels
+*/}}
+{{- define "install.customPodLabels" -}}
+{{- if .Values.customPodLabels -}}
+{{ toYaml .Values.customPodLabels }}
+{{- end}}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "install.serviceAccountName" -}}

--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         {{- include "install.clusterLabels" . | nindent 8 }}
+        {{- include "install.customPodLabels" . | nindent 8 }}
     spec:
       {{- include "install.imagePullSecrets" . | indent 6 }}
       serviceAccountName: {{ include "install.serviceAccountName" . }}

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -44,3 +44,9 @@ imagePullSecretNames: []
 # Resource configuration of the PostgresCluster and PGUpgrade controllers.
 resources:
   controller: {}
+
+# Define custom labels for PGO pods
+# Note: Defining labels that overlap with any Crunchy Data label, for example,
+# postgres-operator.crunchydata.com, will cause an error
+# customPodLabels:
+#  example.com: custom-label


### PR DESCRIPTION
Users can now provide custom pod labels through the values.yaml file. Any labels that overlap with Crunchy labels will lead to duplicate labels in the template and errors returned from the Kube API when creating the resource.