### PR TITLE
add nodeSelector support

### DIFF
--- a/helm/install/templates/manager.yaml
+++ b/helm/install/templates/manager.yaml
@@ -20,6 +20,10 @@ spec:
     spec:
       {{- include "install.imagePullSecrets" . | indent 6 }}
       serviceAccountName: {{ include "install.serviceAccountName" . }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
       containers:
       - name: operator
         image: {{ required ".Values.controllerImages.cluster is required" .Values.controllerImages.cluster | quote }}

--- a/helm/install/values.yaml
+++ b/helm/install/values.yaml
@@ -50,3 +50,6 @@ resources:
 # postgres-operator.crunchydata.com, will cause an error
 # customPodLabels:
 #  example.com: custom-label
+
+# Node labels for pod assignment
+nodeSelector: {}


### PR DESCRIPTION
Supporting (at the very least) `nodeSelector` to constrain where pods run is standard practice in Helm charts, so this PR adds that capability.