### PR TITLE
Update Postgres Image Version to 16.0 in Quickstart Guide for Creating a Postgres Cluster

### DIFF
--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -9,7 +9,7 @@ spec:
     - name: instance1
       dataVolumeClaimSpec:
         accessModes:
-          - "ReadWriteOnce"
+        - "ReadWriteOnce"
         resources:
           requests:
             storage: 1Gi
@@ -17,11 +17,11 @@ spec:
     pgbackrest:
       image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.49-0
       repos:
-        - name: repo1
-          volume:
-            volumeClaimSpec:
-              accessModes:
-                - "ReadWriteOnce"
-              resources:
-                requests:
-                  storage: 1Gi
+      - name: repo1
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 1Gi

--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -3,13 +3,13 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.0-0
   postgresVersion: 16
   instances:
     - name: instance1
       dataVolumeClaimSpec:
         accessModes:
-        - "ReadWriteOnce"
+          - "ReadWriteOnce"
         resources:
           requests:
             storage: 1Gi
@@ -17,11 +17,11 @@ spec:
     pgbackrest:
       image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.49-0
       repos:
-      - name: repo1
-        volume:
-          volumeClaimSpec:
-            accessModes:
-            - "ReadWriteOnce"
-            resources:
-              requests:
-                storage: 1Gi
+        - name: repo1
+          volume:
+            volumeClaimSpec:
+              accessModes:
+                - "ReadWriteOnce"
+              resources:
+                requests:
+                  storage: 1Gi


### PR DESCRIPTION
Summary of Changes
Updated the Postgres image version used in the Quickstart Guide for creating a Postgres cluster from ubi8-15.6-0 to ubi8-16.0-0.

Background
In the official documentation of the CrunchyData Postgres Operator, the Postgres image version used in the section for creating a Postgres cluster was ubi8-15.6-0, which does not comply with the current requirement for Postgres version 16.0 or higher. This discrepancy could potentially lead to errors when users attempt to create a cluster.