### PR TITLE
Update postgres image version to match expected postgresVersion

### DIFF
--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -3,7 +3,7 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
   postgresVersion: 16
   instances:
     - name: instance1


### PR DESCRIPTION
Fix this startup error

2024-02-27T11:40:12.982758505Z stdout F ::postgres-operator: postgres path::/usr/pgsql-15/bin/postgres 2024-02-27T11:40:13.004468422Z stdout F ::postgres-operator: postgres version::postgres (PostgreSQL) 15.6 2024-02-27T11:40:13.004563588Z stderr F Expected PostgreSQL version 16