### PR TITLE
Make PG 16 default

### DIFF
--- a/kustomize/azure/postgres.yaml
+++ b/kustomize/azure/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-azure
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
-  postgresVersion: 15
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
+  postgresVersion: 16
   instances:
     - dataVolumeClaimSpec:
         accessModes:

--- a/kustomize/certmanager/postgres/postgres.yaml
+++ b/kustomize/certmanager/postgres/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
-  postgresVersion: 15
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
+  postgresVersion: 16
   customReplicationTLSSecret:
     name: hippo-repl-tls
   customTLSSecret:

--- a/kustomize/gcs/postgres.yaml
+++ b/kustomize/gcs/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-gcs
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
-  postgresVersion: 15
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
+  postgresVersion: 16
   instances:
     - dataVolumeClaimSpec:
         accessModes:

--- a/kustomize/high-availability/ha-postgres.yaml
+++ b/kustomize/high-availability/ha-postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-ha
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
-  postgresVersion: 15
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
+  postgresVersion: 16
   instances:
     - name: pgha1
       replicas: 2

--- a/kustomize/keycloak/postgres.yaml
+++ b/kustomize/keycloak/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: keycloakdb
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
-  postgresVersion: 15
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
+  postgresVersion: 16
   instances:
     - replicas: 2
       dataVolumeClaimSpec:

--- a/kustomize/multi-backup-repo/postgres.yaml
+++ b/kustomize/multi-backup-repo/postgres.yaml
@@ -3,7 +3,7 @@ kind: PostgresCluster
 metadata:
   name: hippo-multi-repo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
   postgresVersion: 16
   instances:
     - dataVolumeClaimSpec:

--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -3,7 +3,7 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
   postgresVersion: 16
   instances:
     - name: instance1

--- a/kustomize/s3/postgres.yaml
+++ b/kustomize/s3/postgres.yaml
@@ -3,8 +3,8 @@ kind: PostgresCluster
 metadata:
   name: hippo-s3
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-15.6-0
-  postgresVersion: 15
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.2-0
+  postgresVersion: 16
   instances:
     - dataVolumeClaimSpec:
         accessModes:


### PR DESCRIPTION
Now that we have released our .2 release of the newest PG, we should update to using that in our examples.