### PR TITLE
Update cluster deployment examples

### DIFF
--- a/kustomize/azure/postgres.yaml
+++ b/kustomize/azure/postgres.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: hippo-azure
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
   instances:
     - dataVolumeClaimSpec:
@@ -14,7 +13,6 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
       configuration:
       - secret:
           name: pgo-azure-creds

--- a/kustomize/certmanager/postgres/postgres.yaml
+++ b/kustomize/certmanager/postgres/postgres.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
   customReplicationTLSSecret:
     name: hippo-repl-tls
@@ -19,7 +18,6 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
       repos:
       - name: repo1
         volume:

--- a/kustomize/gcs/postgres.yaml
+++ b/kustomize/gcs/postgres.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: hippo-gcs
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
   instances:
     - dataVolumeClaimSpec:
@@ -14,7 +13,6 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
       configuration:
       - secret:
           name: pgo-gcs-creds

--- a/kustomize/high-availability/ha-postgres.yaml
+++ b/kustomize/high-availability/ha-postgres.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: hippo-ha
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
   instances:
     - name: pgha1
@@ -26,7 +25,6 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: pgha1
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
       repos:
       - name: repo1
         volume:
@@ -38,7 +36,6 @@ spec:
                 storage: 1Gi
   proxy:
     pgBouncer:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.22-1
       replicas: 2
       affinity:
         podAntiAffinity:

--- a/kustomize/keycloak/postgres.yaml
+++ b/kustomize/keycloak/postgres.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: keycloakdb
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
   instances:
     - replicas: 2
@@ -25,7 +24,6 @@ spec:
                   postgres-operator.crunchydata.com/instance-set: "00"
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
       repos:
       - name: repo1
         volume:

--- a/kustomize/multi-backup-repo/postgres.yaml
+++ b/kustomize/multi-backup-repo/postgres.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: hippo-multi-repo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
   instances:
     - dataVolumeClaimSpec:
@@ -14,7 +13,6 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
       configuration:
       - secret:
           name: pgo-multi-repo-creds

--- a/kustomize/pgadmin/kustomization.yaml
+++ b/kustomize/pgadmin/kustomization.yaml
@@ -6,3 +6,11 @@ namespace: postgres-operator
 resources:
 - pgadmin.yaml
 
+secretGenerator:
+- name: pgadmin-password-secret
+  literals:
+  - rhino-password=pgadmin
+  type: Opaque
+
+generatorOptions:
+  disableNameSuffixHash: true

--- a/kustomize/pgadmin/pgadmin.yaml
+++ b/kustomize/pgadmin/pgadmin.yaml
@@ -2,8 +2,13 @@ apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PGAdmin
 metadata:
   name: rhino
-  namespace: postgres-operator
 spec:
+  users:
+    - username: rhino@example.com
+      role: Administrator
+      passwordRef:
+        name: pgadmin-password-secret
+        key: rhino-password
   dataVolumeClaimSpec:
     accessModes:
     - "ReadWriteOnce"
@@ -16,20 +21,22 @@ spec:
       postgresClusterSelector: {}
   config:
     settings:
-      AUTHENTICATION_SOURCES: ['oauth2', 'internal']
-      OAUTH2_CONFIG:
-        - OAUTH2_NAME: "google"
-          OAUTH2_DISPLAY_NAME: "Google"
-          OAUTH2_CLIENT_ID: "XXXXXXX"
-          OAUTH2_CLIENT_SECRET: "XXXXXXX"
-          OAUTH2_TOKEN_URL: "https://oauth2.googleapis.com/token"
-          OAUTH2_AUTHORIZATION_URL: "https://accounts.google.com/o/oauth2/auth"
-          OAUTH2_API_BASE_URL: "https://openidconnect.googleapis.com/v1/"
-          OAUTH2_SERVER_METADATA_URL: "https://accounts.google.com/.well-known/openid-configuration"
-          OAUTH2_SCOPE: "openid email profile"
-          OAUTH2_USERINFO_ENDPOINT: "userinfo"
-          OAUTH2_SSL_CERT_VERIFICATION: "False" # for testing purposes
-          OAUTH2_BUTTON_COLOR: "red"   
-      OAUTH2_AUTO_CREATE_USER : "True"
-      DEBUG: "True" # for testing purposes
-      SERVER_MODE: "True"
+      AUTHENTICATION_SOURCES: ['internal']
+      # Uncomment DEBUG to enable debug logging in pgAdmin
+      # DEBUG: "True"
+      # Configure OAUTH by setting the following *AND* adding
+      # `oauth` to AUTHENTICATION_SOURCES
+      #OAUTH2_CONFIG:
+      #  - OAUTH2_NAME: "google"
+      #    OAUTH2_DISPLAY_NAME: "Google"
+      #    OAUTH2_CLIENT_ID: "XXXXXXX"
+      #    OAUTH2_CLIENT_SECRET: "XXXXXXX"
+      #    OAUTH2_TOKEN_URL: "https://oauth2.googleapis.com/token"
+      #    OAUTH2_AUTHORIZATION_URL: "https://accounts.google.com/o/oauth2/auth"
+      #    OAUTH2_API_BASE_URL: "https://openidconnect.googleapis.com/v1/"
+      #    OAUTH2_SERVER_METADATA_URL: "https://accounts.google.com/.well-known/openid-configuration"
+      #    OAUTH2_SCOPE: "openid email profile"
+      #    OAUTH2_USERINFO_ENDPOINT: "userinfo"
+      #    OAUTH2_SSL_CERT_VERIFICATION: "False" # for testing purposes
+      #    OAUTH2_BUTTON_COLOR: "red"   
+      #OAUTH2_AUTO_CREATE_USER : "True"

--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -5,6 +5,10 @@ metadata:
 spec:
   image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
+  users:
+    - name: rhino
+      databases:
+        - zoo
   instances:
     - name: instance1
       dataVolumeClaimSpec:

--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: hippo
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
   users:
     - name: rhino
@@ -19,7 +18,6 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
       repos:
       - name: repo1
         volume:

--- a/kustomize/s3/postgres.yaml
+++ b/kustomize/s3/postgres.yaml
@@ -3,7 +3,6 @@ kind: PostgresCluster
 metadata:
   name: hippo-s3
 spec:
-  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:ubi8-16.3-1
   postgresVersion: 16
   instances:
     - dataVolumeClaimSpec:
@@ -14,7 +13,6 @@ spec:
             storage: 1Gi
   backups:
     pgbackrest:
-      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:ubi8-2.51-1
       configuration:
       - secret:
           name: pgo-s3-creds


### PR DESCRIPTION

- Images can be configured in the operator deployment as RELATED_IMAGES. Reference the [installer configuration docs](https://access.crunchydata.com/documentation/postgres-operator/latest/guides/configuring-cluster-images#configuring-installers) for more information.
- Add user management to the pgAdmin example.
- Add user management to the postgres example.