### PR TITLE
Update Examples for the Latest Version of Keycloak

### DIFF
--- a/kustomize/keycloak/keycloak.yaml
+++ b/kustomize/keycloak/keycloak.yaml
@@ -19,24 +19,24 @@ spec:
         args: ["start-dev"]
         name: keycloak
         env:
-        - name: DB_VENDOR
+        - name: KC_DB
           value: "postgres"
-        - name: DB_ADDR
+        - name: KC_DB_URL_HOST
           valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: host } }
-        - name: DB_PORT
+        - name: KC_DB_URL_PORT
           valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: port } }
-        - name: DB_DATABASE
+        - name: KC_DB_URL_DATABASE
           valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: dbname } }
-        - name: DB_USER
+        - name: KC_DB_USERNAME
           valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: user } }
-        - name: DB_PASSWORD
+        - name: KC_DB_PASSWORD
           valueFrom: { secretKeyRef: { name: keycloakdb-pguser-keycloakdb, key: password } }
-        - name: KEYCLOAK_ADMIN
+        - name: KC_BOOTSTRAP_ADMIN_USERNAME
           value: "admin"
-        - name: KEYCLOAK_ADMIN_PASSWORD
+        - name: KC_BOOTSTRAP_ADMIN_PASSWORD
           value: "admin"
-        - name: KC_PROXY
-          value: "edge"
+        - name: KC_PROXY_HEADERS
+          value: "xforwarded"
         ports:
         - name: http
           containerPort: 8080

--- a/kustomize/keycloak/postgres.yaml
+++ b/kustomize/keycloak/postgres.yaml
@@ -2,6 +2,8 @@ apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
   name: keycloakdb
+  annotations:
+    postgres-operator.crunchydata.com/autoCreateUserSchema: "true"
 spec:
   postgresVersion: 17
   instances:

--- a/kustomize/postgres/postgres.yaml
+++ b/kustomize/postgres/postgres.yaml
@@ -2,10 +2,12 @@ apiVersion: postgres-operator.crunchydata.com/v1beta1
 kind: PostgresCluster
 metadata:
   name: hippo
+  annotations:
+    postgres-operator.crunchydata.com/autoCreateUserSchema: "true"
 spec:
   postgresVersion: 17
   users:
-    - name: rhino
+    - name: hippo
       databases:
         - zoo
   instances:


### PR DESCRIPTION
The Keycloak example now works with the latest version of Keycloak.  This includes using the new env vars and settings that are now available in the latest version of Keycloak.

The PostgresCluster's created for the Keycloak examples (which includes any PostgresCluster's created for use with Keycloak in the Crunchy Postgres for Kubernetes documentation) have also been updated to set the `autoCreateUserSchema` annotation to `true`.  Without this setting, Keycloak will crash on startup when attempting to use the public schema.

Issues: PGO-2300