### PR TITLE
Adds support for configuring instancesAccessMode

### DIFF
--- a/helm/postgres/templates/postgres.yaml
+++ b/helm/postgres/templates/postgres.yaml
@@ -25,7 +25,7 @@ spec:
         storageClassName: {{ .Values.instanceStorageClassName | quote }}
         {{- end }}
         accessModes:
-        - "ReadWriteOnce"
+        - {{ default "ReadWriteOnce" .Values.instanceAccessMode | quote }}
         resources:
           requests:
             storage: {{ default "1Gi" .Values.instanceSize | quote }}

--- a/helm/postgres/values.yaml
+++ b/helm/postgres/values.yaml
@@ -101,6 +101,10 @@ postgresVersion: 17
 # (HA). Settings "instances" overrides this value.
 # instanceReplicas: 1
 
+# instanceAccessMode sets the access mode of Postgres Persistent Volume. This
+# defaults to the value below.
+# instanceAccessMode: "ReadWriteOnce"
+
 ##############################
 # Advanced Postgres Settings #
 ##############################


### PR DESCRIPTION
Adds support for configuring instanceAccessMode. 

This is useful for implementing logging similar to as described here: https://www.crunchydata.com/blog/log-export-examples-using-crunchy-postgres-for-kubernetes

To implement logging as described in the official article one solution is a logging pod that can mount the PVC's as read-only. To do this effectively instanceAccessMode must be "ReadWriteMany" instead of the hard-coded setting of "ReadWriteOnly".